### PR TITLE
mlflow AMD statistics

### DIFF
--- a/aifs-mono-hackathon/aifs-mono-hackathon.yml
+++ b/aifs-mono-hackathon/aifs-mono-hackathon.yml
@@ -95,7 +95,6 @@ dependencies:
   - mdit-py-plugins==0.4.1
   - mdurl==0.1.2
   - memray==1.12.0
-  - mlflow==2.14.0
   - mlflow-export-import==1.2.0
   - multidict==6.0.5
   - multiurl==0.3.1
@@ -187,4 +186,5 @@ dependencies:
   - anemoi-datasets==0.3.7
   - /mnt/anemoi-models
   - /mnt/aifs-mono
+  - /mnt/mlflow
 name: aifs-mono 

--- a/aifs-mono-hackathon/build.sh
+++ b/aifs-mono-hackathon/build.sh
@@ -53,9 +53,14 @@ include aifs/*/*/*/*/*.json
 include aifs/*/*/*/*/*/*.json
 EOF
 
+# Clone the mlflow-branch containing the fix for AMD GPUs
+git clone -b amd-statistics git@github.com:evenmn/mlflow.git $d_SRC/mlflow #This should be merged into the main mlflow branch at some point
+# An additional bugfix
+sed -i "5iimport torch" $d_SRC/mlflow/mlflow/system_metrics/system_metrics_monitor.py
+
 cd $d_WORK
 # Remove previous container
- rm -f $f_SIF
+rm -f $f_SIF
 # Make sure cotainr can see the src directory
 export SINGULARITY_BIND=$d_SRC:/mnt
 cotainr build $f_SIF --base-image=$f_BASE --conda-env=$f_ENV --accept-licenses


### PR DESCRIPTION
This pull request the installation of mlflow 2.14.0 by the pull request https://github.com/mlflow/mlflow/pull/12694, which adds GPU statistics for AMD GPUs.