### PR TITLE
Add support-forcing-area-in-cutout 

### DIFF
--- a/anemoi-lam/anemoi-lam.yml
+++ b/anemoi-lam/anemoi-lam.yml
@@ -13,10 +13,9 @@
     - aiosignal==1.3.1
     - alembic==1.13.3
     - anemoi-datasets==0.5.7
-    - git+https://github.com/ecmwf/anemoi-graphs.git@feature/8-stretched-grid-graphs
+    - git+https://github.com/ecmwf/anemoi-graphs.git@feature/support-forcing-area-in-cutout
     - anemoi-models==0.3.0
-    - git+https://github.com/ecmwf/anemoi-training.git@09fd1e2987b4682f26d52ed16797fa20314ccf2c
-    - anemoi-utils==0.3.18
+    - git+https://github.com/dietervdb-meteo/anemoi-training.git@feature/limited_area_crop
     - aniso8601==9.0.1
     - antlr4-python3-runtime==4.9.3
     - asciitree==0.3.3

--- a/anemoi-lam/readme.md
+++ b/anemoi-lam/readme.md
@@ -5,12 +5,10 @@ After the LUMI-upgrade of 2024-09 the AMD-drivers on LUMI now support ROCm `v6.2
 Base containers with ROCm can be found in `/appl/local/containers/sif-images`.  
 This `anemoi-lam` container uses `lumi-rocm-rocm-6.2.0.sif` as base-image.
 
-In this container the [`feature/limited_area`](https://github.com/ecmwf/anemoi-training/tree/feature/limited_area) branch of `anemoi-training` is installed.  
+In this container the [`feature/limited_area_crop`](https://github.com/dietervdb-meteo/anemoi-training/tree/feature/limited_area_crop) branch of `anemoi-training` is installed.  
 
-More specifically we have pinned the commit hash [`09fd1e`](https://github.com/ecmwf/anemoi-training/commit/09fd1e2987b4682f26d52ed16797fa20314ccf2c).
-
-This branch of `anemoi-training` depends on the [`feature/8-stretched-grid-graphs`](https://github.com/ecmwf/anemoi-graphs/tree/feature/8-stretched-grid-graphs) branch of `anemoi-graphs`. Pinning the commit hash here was not possible as it gave conflicts with the dependencies of `anemoi-training`.  
-Be aware that rebuiling the container might thus introduce newer versions of `anemoi-graphs`!
+This branch of `anemoi-training` depends on the [`feature/support-forcing-area-in-cutout`](https://github.com/ecmwf/anemoi-graphs/tree/feature/support-forcing-area-in-cutout) branch of `anemoi-graphs`.
+We have chosen not to pin the commit hashes, so be aware that rebuiling the container might introduce newer versions of `anemoi-training` and `anemoi-graphs`!
 
 All dependencies were first installed without version specifications and all versions were pinned a-posteriori in the `.yaml`-file.
 


### PR DESCRIPTION
Get anemoi-training from @dietervdb-meteo's branch.
This adds [forcing-area in cutout](https://github.com/ecmwf/anemoi-graphs/tree/feature/support-forcing-area-in-cutout) support to `anemoi-graphs`. 